### PR TITLE
Bug fix for slave_reset generation

### DIFF
--- a/rtl/verilog/i2c_master_bit_ctrl.v
+++ b/rtl/verilog/i2c_master_bit_ctrl.v
@@ -240,13 +240,13 @@ module i2c_master_bit_ctrl (
     always @(posedge clk or negedge nReset)
       if (!nReset)
       begin
-          cSCL <= 2'b00;
-          cSDA <= 2'b00;
+          cSCL <= 2'b11;
+          cSDA <= 2'b11;
       end
       else if (rst)
       begin
-          cSCL <= 2'b00;
-          cSDA <= 2'b00;
+          cSCL <= 2'b11;
+          cSDA <= 2'b11;
       end
       else
       begin
@@ -717,7 +717,7 @@ module i2c_master_bit_ctrl (
           endcase // case (slave_state)
        end
 
-   assign slave_reset = sta_condition | sto_condition;
+   assign slave_reset = !master_mode && (sta_condition || sto_condition);
 
     // assign scl and sda output (always gnd)
     assign scl_o = 1'b0;


### PR DESCRIPTION
 - masked slave_reset with !master_mode
 - fixed incorrect reset terms for cSCL and cSDA which should be
   reset to 2'b11 to match the default pullup state of the bus.
   Without this fix, spurious start/stop conditions are generated.